### PR TITLE
fix: update name to match other plugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,8 @@ import {
  */
 export default async function register(app) {
   await app.registerPlugin({
-    label: "Catalog",
-    name: "reaction-catalog",
+    label: "Catalogs",
+    name: "catalogs",
     version: pkg.version,
     i18n,
     collections: {


### PR DESCRIPTION
Other package names do not have a reaction- prefix. This update syncs this package with all others by removing that.