### PR TITLE
fix: ID decoding

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,11 @@ jobs:
       - run: npm ci
 
       - save_cache:
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
+          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
-          key: v1-dependencies-{{ .Branch }}
+          key: dependencies-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}
           paths:
             - node_modules
 
@@ -31,8 +31,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}
-            - v1-dependencies-{{ .Branch }}
+            - dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "package-lock.json" }}
+            - dependencies-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}
 
       - run: npx semantic-release
 
@@ -45,8 +45,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}
-            - v1-dependencies-{{ .Branch }}
+            - dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "package-lock.json" }}
+            - dependencies-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}
 
       - run: npm run lint
 
@@ -59,8 +59,8 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}
-            - v1-dependencies-{{ .Branch }}
+            - dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "package-lock.json" }}
+            - dependencies-{{ .Environment.CACHE_VERSION }}-{{ .Branch }}
 
       - run: npm run test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:12
+      - image: node:12.14.1
 
     dependencies:
       pre:
@@ -24,7 +24,7 @@ jobs:
 
   deploy:
     docker:
-      - image: node:12
+      - image: node:12.14.1
 
     steps:
       - checkout
@@ -38,7 +38,7 @@ jobs:
 
   lint:
     docker:
-      - image: node:12
+      - image: node:12.14.1
 
     steps:
       - checkout
@@ -52,7 +52,7 @@ jobs:
 
   test:
     docker:
-      - image: node:12
+      - image: node:12.14.1
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,13 @@ jobs:
       - run: npm ci
 
       - save_cache:
+          key: v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
+      - save_cache:
+          key: v1-dependencies-{{ .Branch }}
+          paths:
+            - node_modules
 
   deploy:
     docker:
@@ -27,9 +31,8 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
+            - v1-dependencies-{{ .Branch }}
 
       - run: npx semantic-release
 
@@ -42,9 +45,8 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
+            - v1-dependencies-{{ .Branch }}
 
       - run: npm run lint
 
@@ -57,9 +59,8 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
+            - v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
+            - v1-dependencies-{{ .Branch }}
 
       - run: npm run test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm ci
 
       - save_cache:
-          key: v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
+          key: v1-dependencies-{{ package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
@@ -31,7 +31,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
+            - v1-dependencies-{{ package-lock.json" }}
             - v1-dependencies-{{ .Branch }}
 
       - run: npx semantic-release
@@ -45,7 +45,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
+            - v1-dependencies-{{ package-lock.json" }}
             - v1-dependencies-{{ .Branch }}
 
       - run: npm run lint
@@ -59,7 +59,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "package-lock.json" }}-{{ checksum "package/package-lock.json" }}
+            - v1-dependencies-{{ package-lock.json" }}
             - v1-dependencies-{{ .Branch }}
 
       - run: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - run: npm ci
 
       - save_cache:
-          key: v1-dependencies-{{ package-lock.json" }}
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - save_cache:
@@ -31,7 +31,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ package-lock.json" }}
+            - v1-dependencies-{{ checksum "package-lock.json" }}
             - v1-dependencies-{{ .Branch }}
 
       - run: npx semantic-release
@@ -45,7 +45,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ package-lock.json" }}
+            - v1-dependencies-{{ checksum "package-lock.json" }}
             - v1-dependencies-{{ .Branch }}
 
       - run: npm run lint
@@ -59,7 +59,7 @@ jobs:
 
       - restore_cache:
           keys:
-            - v1-dependencies-{{ package-lock.json" }}
+            - v1-dependencies-{{ checksum "package-lock.json" }}
             - v1-dependencies-{{ .Branch }}
 
       - run: npm run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - save_cache:
           paths:
             - node_modules
-          key: v1-dependencies-{{ checksum "package.json" }}
+          key: v1-dependencies-{{ checksum "package-lock.json" }}
 
   deploy:
     docker:
@@ -27,7 +27,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -42,7 +42,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 
@@ -57,7 +57,7 @@ jobs:
 
       - restore_cache:
           keys:
-          - v1-dependencies-{{ checksum "package.json" }}
+          - v1-dependencies-{{ checksum "package-lock.json" }}
           # fallback to using the latest cache if no exact match is found
           - v1-dependencies-
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1924,9 +1924,9 @@
       }
     },
     "@reactioncommerce/api-utils": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.14.0.tgz",
-      "integrity": "sha512-XnMetnWC3aWk/FpzL2z2S800aRMWTWXwysyVr4ZeVOssSpFsCUEcvjFUYA4XsyEGzB+1qXN2AM7WvHZpMQXNpg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.14.1.tgz",
+      "integrity": "sha512-ucF7HTbix0DzD88r9O9SdrByB76douiagP0Cdeif2zM6r2yL+IrINgjDQZ80SJO60uCodREpXu7c1dq0RKXzNw==",
       "requires": {
         "@jest/globals": "^26.0.1",
         "@reactioncommerce/logger": "^1.1.3",
@@ -4183,14 +4183,14 @@
       }
     },
     "envalid": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/envalid/-/envalid-6.0.1.tgz",
-      "integrity": "sha512-o2+xxQhpp7NSjrSeAJautFVYeNb6MUpEceVVuMoSEfgp9oq4XMb9fp3HODvZuh5Sg9zmrG3a5nClVaY1XqOdlg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/envalid/-/envalid-6.0.2.tgz",
+      "integrity": "sha512-ChJb9a5rjwZ/NkcXfBrzEl5cFZaGLg38N7MlWJkv5qsmSypX2WJe28LkoAWcklC60nKZXYKRlBbsjuJSjYw0Xg==",
       "requires": {
         "chalk": "^3.0.0",
         "dotenv": "^8.2.0",
         "meant": "^1.0.1",
-        "validator": "^12.0.0"
+        "validator": "^13.0.0"
       },
       "dependencies": {
         "chalk": {
@@ -14279,9 +14279,9 @@
       }
     },
     "validator": {
-      "version": "12.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
-      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.0.0.tgz",
+      "integrity": "sha512-anYx5fURbgF04lQV18nEQWZ/3wHGnxiKdG4aL8J+jEDsm98n/sU/bey+tYk6tnGJzm7ioh5FoqrAiQ6m03IgaA=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.8.3"
       }
@@ -257,8 +256,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.9.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
-      "dev": true
+      "integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
     },
     "@babel/helper-wrap-function": {
       "version": "7.8.3",
@@ -287,7 +285,6 @@
       "version": "7.9.0",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
       "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
@@ -1302,6 +1299,187 @@
         "lolex": "^5.0.0"
       }
     },
+    "@jest/globals": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.0.1.tgz",
+      "integrity": "sha512-iuucxOYB7BRCvT+TYBzUqUNuxFX1hqaR6G6IcGgEqkJ5x4htNKo1r7jk1ji9Zj8ZMiMw0oB5NaA7k5Tx6MVssA==",
+      "requires": {
+        "@jest/environment": "^26.0.1",
+        "@jest/types": "^26.0.1",
+        "expect": "^26.0.1"
+      },
+      "dependencies": {
+        "@jest/environment": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.0.1.tgz",
+          "integrity": "sha512-xBDxPe8/nx251u0VJ2dFAFz2H23Y98qdIaNwnMK6dFQr05jc+Ne/2np73lOAx+5mSBO/yuQldRrQOf6hP1h92g==",
+          "requires": {
+            "@jest/fake-timers": "^26.0.1",
+            "@jest/types": "^26.0.1",
+            "jest-mock": "^26.0.1"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.0.1.tgz",
+          "integrity": "sha512-Oj/kCBnTKhm7CR+OJSjZty6N1bRDr9pgiYQr4wY221azLz5PHi08x/U+9+QpceAYOWheauLP8MhtSVFrqXQfhg==",
+          "requires": {
+            "@jest/types": "^26.0.1",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.0.1",
+            "jest-mock": "^26.0.1",
+            "jest-util": "^26.0.1"
+          }
+        },
+        "@jest/types": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.0.1.tgz",
+          "integrity": "sha512-IbtjvqI9+eS1qFnOIEL7ggWmT+iK/U+Vde9cGWtYb/b6XgKb3X44ZAe/z9YZzoAAZ/E92m0DqrilF934IGNnQA==",
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "chalk": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "diff-sequences": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
+          "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg=="
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        },
+        "expect": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.0.1.tgz",
+          "integrity": "sha512-QcCy4nygHeqmbw564YxNbHTJlXh47dVID2BUP52cZFpLU9zHViMFK6h07cC1wf7GYCTIigTdAXhVua8Yl1FkKg==",
+          "requires": {
+            "@jest/types": "^26.0.1",
+            "ansi-styles": "^4.0.0",
+            "jest-get-type": "^26.0.0",
+            "jest-matcher-utils": "^26.0.1",
+            "jest-message-util": "^26.0.1",
+            "jest-regex-util": "^26.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "jest-diff": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.0.1.tgz",
+          "integrity": "sha512-odTcHyl5X+U+QsczJmOjWw5tPvww+y9Yim5xzqxVl/R1j4z71+fHW4g8qu1ugMmKdFdxw+AtQgs5mupPnzcIBQ==",
+          "requires": {
+            "chalk": "^4.0.0",
+            "diff-sequences": "^26.0.0",
+            "jest-get-type": "^26.0.0",
+            "pretty-format": "^26.0.1"
+          }
+        },
+        "jest-get-type": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+          "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg=="
+        },
+        "jest-matcher-utils": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.0.1.tgz",
+          "integrity": "sha512-PUMlsLth0Azen8Q2WFTwnSkGh2JZ8FYuwijC8NR47vXKpsrKmA1wWvgcj1CquuVfcYiDEdj985u5Wmg7COEARw==",
+          "requires": {
+            "chalk": "^4.0.0",
+            "jest-diff": "^26.0.1",
+            "jest-get-type": "^26.0.0",
+            "pretty-format": "^26.0.1"
+          }
+        },
+        "jest-message-util": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.0.1.tgz",
+          "integrity": "sha512-CbK8uQREZ8umUfo8+zgIfEt+W7HAHjQCoRaNs4WxKGhAYBGwEyvxuK81FXa7VeB9pwDEXeeKOB2qcsNVCAvB7Q==",
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/types": "^26.0.1",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "micromatch": "^4.0.2",
+            "slash": "^3.0.0",
+            "stack-utils": "^2.0.2"
+          }
+        },
+        "jest-mock": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.0.1.tgz",
+          "integrity": "sha512-MpYTBqycuPYSY6xKJognV7Ja46/TeRbAZept987Zp+tuJvMN0YBWyyhG9mXyYQaU3SBI0TUlSaO5L3p49agw7Q==",
+          "requires": {
+            "@jest/types": "^26.0.1"
+          }
+        },
+        "jest-regex-util": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+          "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A=="
+        },
+        "jest-util": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.0.1.tgz",
+          "integrity": "sha512-byQ3n7ad1BO/WyFkYvlWQHTsomB6GIewBh8tlGtusiylAlaxQ1UpS0XYH0ngOyhZuHVLN79Qvl6/pMiDMSSG1g==",
+          "requires": {
+            "@jest/types": "^26.0.1",
+            "chalk": "^4.0.0",
+            "graceful-fs": "^4.2.4",
+            "is-ci": "^2.0.0",
+            "make-dir": "^3.0.0"
+          }
+        },
+        "pretty-format": {
+          "version": "26.0.1",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.0.1.tgz",
+          "integrity": "sha512-SWxz6MbupT3ZSlL0Po4WF/KujhQaVehijR2blyRDCzk9e45EaYMVhMBn49fnRuHxtkSpXTes1GxNpVmH86Bxfw==",
+          "requires": {
+            "@jest/types": "^26.0.1",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "stack-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+          "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+          "requires": {
+            "escape-string-regexp": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@jest/reporters": {
       "version": "25.3.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-25.3.0.tgz",
@@ -1746,16 +1924,17 @@
       }
     },
     "@reactioncommerce/api-utils": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.10.1.tgz",
-      "integrity": "sha512-0jSi4R8j8pTtOimbEpsB0OSilotXpgo+tEhGPvuWevl7Tj8XD69WDougQ8COL+LXxFMi/ZK2C60F7iLbFDCPSw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@reactioncommerce/api-utils/-/api-utils-1.14.0.tgz",
+      "integrity": "sha512-XnMetnWC3aWk/FpzL2z2S800aRMWTWXwysyVr4ZeVOssSpFsCUEcvjFUYA4XsyEGzB+1qXN2AM7WvHZpMQXNpg==",
       "requires": {
+        "@jest/globals": "^26.0.1",
         "@reactioncommerce/logger": "^1.1.3",
         "@reactioncommerce/random": "^1.0.2",
         "@reactioncommerce/reaction-error": "^1.0.1",
         "accounting-js": "^1.1.1",
         "callsite": "^1.0.0",
-        "graphql": "^14.6.0",
+        "envalid": "^6.0.1",
         "graphql-fields": "^2.0.3",
         "graphql-relay": "^0.6.0",
         "lodash": "^4.17.15",
@@ -2085,9 +2264,16 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
       "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
-      "dev": true,
       "requires": {
         "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "@tootallnate/once": {
@@ -2145,14 +2331,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
-      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
-      "dev": true
+      "integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -2161,7 +2345,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
       "integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*",
         "@types/istanbul-lib-report": "*"
@@ -2206,14 +2389,12 @@
     "@types/stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
-      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
-      "dev": true
+      "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw=="
     },
     "@types/yargs": {
       "version": "15.0.4",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.4.tgz",
       "integrity": "sha512-9T1auFmbPZoxHz0enUFlUuKRy3it01R+hlggyVUMtnCTQRunsQYifnSGb8hET4Xo8yiC0o0r1paW3ud5+rbURg==",
-      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -2221,8 +2402,7 @@
     "@types/yargs-parser": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==",
-      "dev": true
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@typescript-eslint/experimental-utils": {
       "version": "2.28.0",
@@ -3031,7 +3211,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -3227,7 +3406,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3238,7 +3416,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -3247,7 +3424,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -3255,8 +3431,7 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         }
       }
     },
@@ -3269,8 +3444,7 @@
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
-      "dev": true
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -3871,6 +4045,11 @@
         "is-obj": "^1.0.0"
       }
     },
+    "dotenv": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+    },
     "dtrace-provider": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
@@ -4003,6 +4182,41 @@
         }
       }
     },
+    "envalid": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/envalid/-/envalid-6.0.1.tgz",
+      "integrity": "sha512-o2+xxQhpp7NSjrSeAJautFVYeNb6MUpEceVVuMoSEfgp9oq4XMb9fp3HODvZuh5Sg9zmrG3a5nClVaY1XqOdlg==",
+      "requires": {
+        "chalk": "^3.0.0",
+        "dotenv": "^8.2.0",
+        "meant": "^1.0.1",
+        "validator": "^12.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -4053,8 +4267,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.14.1",
@@ -4845,7 +5058,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -5146,14 +5358,6 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
-    "graphql": {
-      "version": "14.6.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
-      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
-      "requires": {
-        "iterall": "^1.2.2"
-      }
-    },
     "graphql-fields": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-2.0.3.tgz",
@@ -5238,8 +5442,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -5669,7 +5872,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
       "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
-      "dev": true,
       "requires": {
         "ci-info": "^2.0.0"
       }
@@ -5760,8 +5962,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-obj": {
       "version": "1.0.1",
@@ -5967,11 +6168,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "iterall": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
-      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "java-properties": {
       "version": "1.0.2",
@@ -6925,8 +7121,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.1",
@@ -7447,7 +7642,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
       "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
-      "dev": true,
       "requires": {
         "semver": "^6.0.0"
       },
@@ -7455,8 +7649,7 @@
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -7537,6 +7730,11 @@
         }
       }
     },
+    "meant": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meant/-/meant-1.0.1.tgz",
+      "integrity": "sha512-UakVLFjKkbbUwNWJ2frVLnnAtbb7D7DsloxRd3s/gDpI8rdv8W5Hp3NaDb+POBI1fQdeussER6NB8vpcRURvlg=="
+    },
     "meow": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
@@ -7595,7 +7793,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
       "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.1",
         "picomatch": "^2.0.5"
@@ -11764,8 +11961,7 @@
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
     "pify": {
       "version": "3.0.0",
@@ -12111,8 +12307,7 @@
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
       "version": "3.0.0",
@@ -13034,8 +13229,7 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "slice-ansi": {
       "version": "2.1.0",
@@ -13545,7 +13739,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -13794,7 +13987,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }
@@ -13818,11 +14010,11 @@
       }
     },
     "transliteration": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.1.8.tgz",
-      "integrity": "sha512-ds3uRxcS0yCxzP4xP30dz+ImEeVhgAwSaewhlApuYYTUuT8+wFFLoFfO1nHvfJzbpoRBp4lS52Ai3wm8IkemIQ==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/transliteration/-/transliteration-2.1.11.tgz",
+      "integrity": "sha512-CMCKB2VHgc9JabQ3NiC2aXG5hEd3FKoU+F+zRQJoDRtZFdQwLYKfRSK8zH/B/4HML4WnOx8U0xmob1ehlt/xvw==",
       "requires": {
-        "yargs": "^15.0.2"
+        "yargs": "^15.3.1"
       }
     },
     "traverse": {
@@ -13883,8 +14075,7 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.8.1",
@@ -14086,6 +14277,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-12.2.0.tgz",
+      "integrity": "sha512-jJfE/DW6tIK1Ek8nCfNFqt8Wb3nzMoAbocBF6/Icgg1ZFSBpObdnwVY2jQj6qUqzhx5jc71fpvBWyLGO7Xl+nQ=="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@reactioncommerce/api-utils": "^1.14.0",
+    "@reactioncommerce/api-utils": "^1.14.1",
     "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/random": "^1.0.2",
     "@reactioncommerce/reaction-error": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@reactioncommerce/api-utils": "^1.9.0",
+    "@reactioncommerce/api-utils": "^1.14.0",
     "@reactioncommerce/logger": "^1.1.3",
     "@reactioncommerce/random": "^1.0.2",
     "@reactioncommerce/reaction-error": "^1.0.1",

--- a/src/queries/catalogItemProduct.js
+++ b/src/queries/catalogItemProduct.js
@@ -20,8 +20,7 @@ export default async function catalogItemProduct(context, { catalogIdOrProductSl
     throw new ReactionError("invalid-param", "You must provide a product slug or product id");
   }
 
-  return Catalog.findOne({
-    shopId,
+  const query = {
     "product.isDeleted": { $ne: true },
     "product.isVisible": true,
     "$or": [
@@ -32,5 +31,11 @@ export default async function catalogItemProduct(context, { catalogIdOrProductSl
         "product.slug": catalogIdOrProductSlug
       }
     ]
-  });
+  };
+
+  if (shopId) {
+    query.shopId = shopId;
+  }
+
+  return Catalog.findOne(query);
 }

--- a/src/queries/catalogItemProduct.js
+++ b/src/queries/catalogItemProduct.js
@@ -21,7 +21,7 @@ export default async function catalogItemProduct(context, { catalogIdOrProductSl
   }
 
   return Catalog.findOne({
-    "shopId": shopId,
+    shopId,
     "product.isDeleted": { $ne: true },
     "product.isVisible": true,
     "$or": [

--- a/src/queries/catalogItemProduct.test.js
+++ b/src/queries/catalogItemProduct.test.js
@@ -14,27 +14,47 @@ beforeEach(() => {
 
 // expect query by product slug
 test("returns a product from the catalog collection by product slug", async () => {
-  const query = { ...mockQueryBase, "product.slug": productSlug };
+  const query = {
+    ...mockQueryBase,
+    shopId: "123",
+    $or: [
+      { _id: productSlug },
+      { "product.slug": productSlug }
+    ]
+  };
   mockContext.collections.Catalog.findOne.mockReturnValueOnce("CATALOGPRODUCT");
-  const result = await catalogItemProduct(mockContext, { slug: productSlug });
+  const result = await catalogItemProduct(mockContext, { catalogIdOrProductSlug: productSlug, shopId: "123" });
   expect(mockContext.collections.Catalog.findOne).toHaveBeenCalledWith(query);
   expect(result).toBe("CATALOGPRODUCT");
 });
 
 // expect query by product _id
 test("returns a product from the catalog collection by product ID", async () => {
-  const query = { ...mockQueryBase, _id: productId };
+  const query = {
+    ...mockQueryBase,
+    shopId: "123",
+    $or: [
+      { _id: productId },
+      { "product.slug": productId }
+    ]
+  };
   mockContext.collections.Catalog.findOne.mockReturnValueOnce("CATALOGPRODUCT");
-  const result = await catalogItemProduct(mockContext, { _id: productId });
+  const result = await catalogItemProduct(mockContext, { catalogIdOrProductSlug: productId, shopId: "123" });
   expect(mockContext.collections.Catalog.findOne).toHaveBeenCalledWith(query);
   expect(result).toBe("CATALOGPRODUCT");
 });
 
 // expect query by id if both slug and id are provided as params
 test("returns a product from the catalog collection by product ID if both slug and ID are provided as params", async () => {
-  const query = { ...mockQueryBase, _id: productId };
+  const query = {
+    ...mockQueryBase,
+    $or: [
+      { _id: productId },
+      { "product.slug": productId }
+    ]
+  };
   mockContext.collections.Catalog.findOne.mockReturnValueOnce("CATALOGPRODUCT");
-  const result = await catalogItemProduct(mockContext, { _id: productId, slug: productSlug });
+  const result = await catalogItemProduct(mockContext, { catalogIdOrProductSlug: productId });
   expect(mockContext.collections.Catalog.findOne).toHaveBeenCalledWith(query);
   expect(result).toBe("CATALOGPRODUCT");
 });

--- a/src/resolvers/Query/catalogItemProduct.js
+++ b/src/resolvers/Query/catalogItemProduct.js
@@ -15,22 +15,11 @@ import { decodeCatalogItemOpaqueId, decodeShopOpaqueId } from "../../xforms/id.j
 export default async function catalogItemProduct(_, args, context) {
   const { shopId: opaqueShopId, slugOrId } = args;
 
-  let productId;
-  let productSlug;
-  try {
-    productId = decodeCatalogItemOpaqueId(slugOrId);
-  } catch (error) {
-    productSlug = slugOrId;
-  }
-
-  let shopId;
-  if (opaqueShopId) {
-    shopId = decodeShopOpaqueId(opaqueShopId);
-  }
+  const catalogIdOrProductSlug = decodeCatalogItemOpaqueId(slugOrId);
+  const shopId = decodeShopOpaqueId(opaqueShopId);
 
   return context.queries.catalogItemProduct(context, {
-    _id: productId,
-    shopId,
-    slug: productSlug
+    catalogIdOrProductSlug,
+    shopId
   });
 }

--- a/src/resolvers/Query/catalogItemProduct.js
+++ b/src/resolvers/Query/catalogItemProduct.js
@@ -16,7 +16,11 @@ export default async function catalogItemProduct(_, args, context) {
   const { shopId: opaqueShopId, slugOrId } = args;
 
   const catalogIdOrProductSlug = decodeCatalogItemOpaqueId(slugOrId);
-  const shopId = decodeShopOpaqueId(opaqueShopId);
+
+  let shopId;
+  if (opaqueShopId) {
+    shopId = decodeShopOpaqueId(opaqueShopId);
+  }
 
   return context.queries.catalogItemProduct(context, {
     catalogIdOrProductSlug,

--- a/src/resolvers/Query/catalogItemProduct.test.js
+++ b/src/resolvers/Query/catalogItemProduct.test.js
@@ -18,6 +18,7 @@ test("calls queries.catalogItemProduct with a product slug and return a CatalogI
   const result = await catalogItemProductResolver(
     {},
     {
+      shopId: "123",
       slugOrId
     },
     {
@@ -25,7 +26,10 @@ test("calls queries.catalogItemProduct with a product slug and return a CatalogI
     }
   );
 
-  expect(catalogItemProduct).toHaveBeenCalledWith(jasmine.any(Object), { _id: undefined, slug: productSlug });
+  expect(catalogItemProduct).toHaveBeenCalledWith(jasmine.any(Object), {
+    catalogIdOrProductSlug: productSlug,
+    shopId: "123"
+  });
   expect(result).toEqual(mockItem);
 });
 
@@ -39,6 +43,7 @@ test("calls queries.catalogItemProduct with a product id and return a CatalogIte
   const result = await catalogItemProductResolver(
     {},
     {
+      shopId: "123",
       slugOrId
     },
     {
@@ -46,6 +51,9 @@ test("calls queries.catalogItemProduct with a product id and return a CatalogIte
     }
   );
 
-  expect(catalogItemProduct).toHaveBeenCalledWith(jasmine.any(Object), { _id: "123", slug: undefined });
+  expect(catalogItemProduct).toHaveBeenCalledWith(jasmine.any(Object), {
+    catalogIdOrProductSlug: "123",
+    shopId: "123"
+  });
   expect(result).toEqual(mockItem);
 });


### PR DESCRIPTION
Resolves #3
Impact: **critical**
Type: **bugfix**

## Issue
`slugOrId` decoding was broken due to an update to `api-utils`

## Solution

- Pin to the latest version of `api-utils`
- Update decoding logic in resolver and Mongo query

## Breaking changes

none

## Testing
1. check out repo next to your `reaction` repo (Reaction 3.8.0 branch: https://github.com/reactioncommerce/reaction/pull/6253)
2. from your `reaction` directory run `bin/package-link api-plugin-catalogs ../api-plugin-catalogs`
3. Run the queries

```
# Get shop id
query q1 {
  primaryShopId  
}

# Get products
query q2 {
	catalogItems(shopIds: ["<SHOP_ID>"]) {
    nodes {
      _id
      ... on CatalogItemProduct {
        product {
          slug
        }
      }
    }
  }
}

# query by the slug
query q3 {
  catalogItemProduct(
    shopId: "<SHOP_ID>", 
    slugOrId: "<SLUG>"
  ) {
    _id
    product {
      slug
    }
  }
}

#query by the catalog item ID (not the product id)
query q4 {
  catalogItemProduct(
    shopId: "<SHOP_ID>", 
    slugOrId: "<CATALOG_ITEM_ID>"
  ) {
    _id
    product {
      slug
    }
  }
}
```
