### PR TITLE
Text search as part of catalogItems

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,18 @@ export default async function register(app) {
           [{ "product.productId": 1 }, { unique: true }],
           [{ "product.slug": 1 }],
           [{ "product.tagIds": 1 }],
-          [{ "$**": "text" }]
+          [{
+            "product.barcode": "text",
+            "product.description": "text",
+            "product.metafields.key": "text",
+            "product.metafields.value": "text",
+            "product.metaDescription": "text",
+            "product.pageTitle": "text",
+            "product.sku": "text",
+            "product.slug": "text",
+            "product.title": "text",
+            "product.vendor": "text"
+          }]
         ]
       }
     },

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,8 @@ export default async function register(app) {
           [{ "product._id": 1 }, { unique: true }],
           [{ "product.productId": 1 }, { unique: true }],
           [{ "product.slug": 1 }],
-          [{ "product.tagIds": 1 }]
+          [{ "product.tagIds": 1 }],
+          [{ "$**": "text" }]
         ]
       }
     },

--- a/src/queries/catalogItems.js
+++ b/src/queries/catalogItems.js
@@ -30,8 +30,8 @@ export default async function catalogItems(context, { searchQuery, shopIds, tagI
   if (tagIds) query["product.tagIds"] = { $in: tagIds };
 
   if (searchQuery) {
-    query["$text"] = {
-      "$search": searchQuery
+    query.$text = {
+      $search: searchQuery
     };
   }
 

--- a/src/queries/catalogItems.js
+++ b/src/queries/catalogItems.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import ReactionError from "@reactioncommerce/reaction-error";
 
 /**
@@ -31,7 +32,7 @@ export default async function catalogItems(context, { searchQuery, shopIds, tagI
 
   if (searchQuery) {
     query.$text = {
-      $search: searchQuery
+      $search: _.escapeRegExp(searchQuery)
     };
   }
 

--- a/src/queries/catalogItems.js
+++ b/src/queries/catalogItems.js
@@ -7,11 +7,12 @@ import ReactionError from "@reactioncommerce/reaction-error";
  * @summary query the Catalog by shop ID and/or tag ID
  * @param {Object} context - an object containing the per-request state
  * @param {Object} params - request parameters
+ * @param {String[]} [params.searchQuery] - Optional text search query
  * @param {String[]} [params.shopIds] - Shop IDs to include (OR)
  * @param {String[]} [params.tags] - Tag IDs to include (OR)
  * @returns {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */
-export default async function catalogItems(context, { shopIds, tagIds, catalogBooleanFilters } = {}) {
+export default async function catalogItems(context, { searchQuery, shopIds, tagIds, catalogBooleanFilters } = {}) {
   const { collections } = context;
   const { Catalog } = collections;
 
@@ -27,6 +28,12 @@ export default async function catalogItems(context, { shopIds, tagIds, catalogBo
 
   if (shopIds) query.shopId = { $in: shopIds };
   if (tagIds) query["product.tagIds"] = { $in: tagIds };
+
+  if (searchQuery) {
+    query["$text"] = {
+      "$search": searchQuery
+    };
+  }
 
   return Catalog.find(query);
 }

--- a/src/queries/catalogItemsAggregate.js
+++ b/src/queries/catalogItemsAggregate.js
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import ReactionError from "@reactioncommerce/reaction-error";
 import arrayJoinPlusRemainingQuery from "@reactioncommerce/api-utils/arrayJoinPlusRemainingQuery.js";
 
@@ -39,7 +40,7 @@ export default async function catalogItemsAggregate(context, {
 
   if (searchQuery) {
     selector.$text = {
-      $search: searchQuery
+      $search: _.escapeRegExp(searchQuery)
     };
   }
 

--- a/src/queries/catalogItemsAggregate.js
+++ b/src/queries/catalogItemsAggregate.js
@@ -9,6 +9,7 @@ import arrayJoinPlusRemainingQuery from "@reactioncommerce/api-utils/arrayJoinPl
  * @param {Object} context - An object containing the per-request state
  * @param {Object} params - Request parameters
  * @param {Object} [params.catalogBooleanFilters] - Additional filters object to add to the selector
+ * @param {String} params.searchQuery - Optional text search query
  * @param {String[]} [params.shopIds] - Shop IDs to include
  * @param {String} params.tagId - Tag ID
  * @returns {Promise<MongoCursor>} - A MongoDB cursor for the proper query
@@ -16,6 +17,7 @@ import arrayJoinPlusRemainingQuery from "@reactioncommerce/api-utils/arrayJoinPl
 export default async function catalogItemsAggregate(context, {
   connectionArgs,
   catalogBooleanFilters,
+  searchQuery,
   shopIds,
   tagId
 } = {}) {
@@ -33,6 +35,12 @@ export default async function catalogItemsAggregate(context, {
 
   if (shopIds && shopIds.length > 0) {
     selector.shopId = { $in: shopIds };
+  }
+
+  if (searchQuery) {
+    selector["$text"] = {
+      "$search": searchQuery
+    };
   }
 
   return arrayJoinPlusRemainingQuery({

--- a/src/queries/catalogItemsAggregate.js
+++ b/src/queries/catalogItemsAggregate.js
@@ -38,8 +38,8 @@ export default async function catalogItemsAggregate(context, {
   }
 
   if (searchQuery) {
-    selector["$text"] = {
-      "$search": searchQuery
+    selector.$text = {
+      $search: searchQuery
     };
   }
 

--- a/src/resolvers/Query/catalogItems.js
+++ b/src/resolvers/Query/catalogItems.js
@@ -12,15 +12,16 @@ import xformCatalogBooleanFilters from "../../utils/catalogBooleanFilters.js";
  * @summary Get a list of catalogItems
  * @param {Object} _ - unused
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client
+ * @param {String[]} [args.searchQuery] - limit to catalog items matching this text search query
  * @param {String[]} [args.shopIds] - limit to catalog items for these shops
- * @param {String[]} [args.tagIds] - limit to catalog items with this array of tags
+ * @param {String[]} [args.tagIds] - limit to catalog items with this array  of tags
  * @param {Object[]} [args.booleanFilters] - Array of boolean filter objects with `name` and `value`
  * @param {Object} context - an object containing the per-request state
  * @param {Object} info Info about the GraphQL request
  * @returns {Promise<Object>} A CatalogItemConnection object
  */
 export default async function catalogItems(_, args, context, info) {
-  const { shopIds: opaqueShopIds, tagIds: opaqueTagIds, booleanFilters, ...connectionArgs } = args;
+  const { shopIds: opaqueShopIds, tagIds: opaqueTagIds, booleanFilters, searchQuery, ...connectionArgs } = args;
 
   const shopIds = opaqueShopIds && opaqueShopIds.map(decodeShopOpaqueId);
   const tagIds = opaqueTagIds && opaqueTagIds.map(decodeTagOpaqueId);
@@ -41,6 +42,7 @@ export default async function catalogItems(_, args, context, info) {
     return context.queries.catalogItemsAggregate(context, {
       catalogBooleanFilters,
       connectionArgs,
+      searchQuery,
       shopIds,
       tagId
     });
@@ -69,6 +71,7 @@ export default async function catalogItems(_, args, context, info) {
 
   const query = await context.queries.catalogItems(context, {
     catalogBooleanFilters,
+    searchQuery,
     shopIds,
     tagIds
   });

--- a/src/resolvers/Query/catalogItems.js
+++ b/src/resolvers/Query/catalogItems.js
@@ -14,7 +14,7 @@ import xformCatalogBooleanFilters from "../../utils/catalogBooleanFilters.js";
  * @param {ConnectionArgs} args - an object of all arguments that were sent by the client
  * @param {String[]} [args.searchQuery] - limit to catalog items matching this text search query
  * @param {String[]} [args.shopIds] - limit to catalog items for these shops
- * @param {String[]} [args.tagIds] - limit to catalog items with this array  of tags
+ * @param {String[]} [args.tagIds] - limit to catalog items with this array of tags
  * @param {Object[]} [args.booleanFilters] - Array of boolean filter objects with `name` and `value`
  * @param {Object} context - an object containing the per-request state
  * @param {Object} info Info about the GraphQL request

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -381,6 +381,9 @@ extend type Query {
     "Additional filters to apply"
     booleanFilters: [CatalogBooleanFilter],
 
+    "Optional text search query"
+    searchQuery: String,
+
     "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
     after: ConnectionCursor,
 


### PR DESCRIPTION
Impact: **major**
Type: **feature**

## Issue
There is currently no way to pass a text search query which will return matching products.

## Solution
This PR adds a `searchQuery` parameter to the `catalogItems` query. A `text` index is added to the following fields of the `Catalog` collection:

- `product.barcode`
- `product.description`
- `product.metafields.key`
- `product.metafields.value`
- `product.metaDescription`
- `product.pageTitle`
- `product.sku`
- `product.slug`
- `product.title`
 - `product.vendor`

Open question for the community and the core team to answer: should we also index the variants and options of the products?

## Breaking changes
None.

## Testing
1. Query `catalogItems` with `shopsId` and ` searchQuery`. The query should return products within the specified shops matching the query.
2. Add a `tagIds` array. The query should return matching products within the specified shops and within the specific tags.