### PR TITLE
Add vendors query

### DIFF
--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -4,6 +4,7 @@ import catalogItemProduct from "./catalogItemProduct.js";
 import findCatalogProductsAndVariants from "./findCatalogProductsAndVariants.js";
 import findProductAndVariant from "./findProductAndVariant.js";
 import findVariantInCatalogProduct from "./findVariantInCatalogProduct.js";
+import vendors from "./vendors.js";
 
 export default {
   catalogItems,
@@ -11,5 +12,6 @@ export default {
   catalogItemProduct,
   findCatalogProductsAndVariants,
   findProductAndVariant,
-  findVariantInCatalogProduct
+  findVariantInCatalogProduct,
+  vendors
 };

--- a/src/queries/vendors.js
+++ b/src/queries/vendors.js
@@ -1,0 +1,38 @@
+/**
+ * @name vendors
+ * @method
+ * @memberof Catalog/NoMeteorQueries
+ * @summary get an array containing all the values for the `product.vendor` field in the Catalog
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} params - request parameters
+ * @param {String[]} [params.shopIds] - Optional IDs of the shop to get a list of vendors for
+ * @param {String[]} [params.tagIds] - Optional IDs of the tags to get a list of vendors for
+ * @returns {Promise<MongoCursor>} - A MongoDB cursor for the proper query
+ */
+export default async function vendors(context, { shopIds, tagIds } = {}) {
+  console.log("vendors query");
+
+  const { collections } = context;
+  const { Catalog } = collections;
+
+  const query = {};
+
+  if (shopIds) query.shopId = { $in: shopIds };
+  if (tagIds) query["product.tagIds"] = { $in: tagIds };
+
+  console.log("query", query);
+
+  return Catalog.aggregate([
+    {
+      $group: {
+        _id: "product.vendor"
+      }
+    },
+    {
+      $project: {
+        _id: false,
+
+      }
+    }
+  ]);
+}

--- a/src/queries/vendors.js
+++ b/src/queries/vendors.js
@@ -10,8 +10,6 @@
  * @returns {Promise<MongoCursor>} - A MongoDB cursor for the proper query
  */
 export default async function vendors(context, { shopIds, tagIds } = {}) {
-  console.log("vendors query");
-
   const { collections } = context;
   const { Catalog } = collections;
 
@@ -20,19 +18,22 @@ export default async function vendors(context, { shopIds, tagIds } = {}) {
   if (shopIds) query.shopId = { $in: shopIds };
   if (tagIds) query["product.tagIds"] = { $in: tagIds };
 
-  console.log("query", query);
-
-  return Catalog.aggregate([
-    {
-      $group: {
-        _id: "product.vendor"
+  return {
+    collection: Catalog,
+    pipeline: [
+      {
+        $group: {
+          _id: "$product.vendor",
+          name: {
+            $first: "$product.vendor"
+          }
+        }
+      },
+      {
+        $project: {
+          _id: false
+        }
       }
-    },
-    {
-      $project: {
-        _id: false,
-
-      }
-    }
-  ]);
+    ]
+  };
 }

--- a/src/queries/vendors.js
+++ b/src/queries/vendors.js
@@ -7,7 +7,7 @@
  * @param {Object} params - request parameters
  * @param {String[]} [params.shopIds] - Optional IDs of the shop to get a list of vendors for
  * @param {String[]} [params.tagIds] - Optional IDs of the tags to get a list of vendors for
- * @returns {Promise<MongoCursor>} - A MongoDB cursor for the proper query
+ * @returns {Object} - An aggregation object to be used by `getPaginatedResponseFromAggregate`
  */
 export default async function vendors(context, { shopIds, tagIds } = {}) {
   const { collections } = context;

--- a/src/resolvers/Query/index.js
+++ b/src/resolvers/Query/index.js
@@ -1,7 +1,9 @@
 import catalogItems from "./catalogItems.js";
 import catalogItemProduct from "./catalogItemProduct.js";
+import vendors from "./vendors.js";
 
 export default {
   catalogItems,
-  catalogItemProduct
+  catalogItemProduct,
+  vendors
 };

--- a/src/resolvers/Query/vendors.js
+++ b/src/resolvers/Query/vendors.js
@@ -26,7 +26,7 @@ export default async function vendors(_, args, context, info) {
     tagIds
   });
 
-  return getPaginatedResponseFromAggregate(collection, pipeline, connectionArgs, {
+  return getPaginatedResponseFromAggregate(collection, pipeline, { ...connectionArgs, sortBy: "name" }, {
     includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
     includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
     includeTotalCount: wasFieldRequested("totalCount", info)

--- a/src/resolvers/Query/vendors.js
+++ b/src/resolvers/Query/vendors.js
@@ -1,0 +1,38 @@
+import getPaginatedResponseFromAggregate from "@reactioncommerce/api-utils/graphql/getPaginatedResponseFromAggregate.js";
+import wasFieldRequested from "@reactioncommerce/api-utils/graphql/wasFieldRequested.js";
+import { decodeShopOpaqueId, decodeTagOpaqueId } from "../../xforms/id.js";
+
+/**
+ * @name Query/vendors
+ * @method
+ * @memberof Catalog/GraphQL
+ * @summary Get a list of all the vendors
+ * @param {Object} _ - unused
+ * @param {ConnectionArgs} args - an object of all arguments that were sent by the client
+ * @param {String[]} args.shopIds - Optional IDs of the shop to get a list of vendors for
+ * @param {String[]} args.tagIds - Optional IDs of the tags to get a list of vendors for
+ * @param {Object} context - an object containing the per-request state
+ * @param {Object} info Info about the GraphQL request
+ * @returns {Promise<Object>} A CatalogItemConnection object
+ */
+export default async function vendors(_, args, context, info) {
+  const { shopIds: opaqueShopIds, tagIds: opaqueTagIds, ...connectionArgs } = args;
+
+  const shopIds = opaqueShopIds && opaqueShopIds.map(decodeShopOpaqueId);
+  const tagIds = opaqueTagIds && opaqueTagIds.map(decodeTagOpaqueId);
+
+  console.log("vendors resolver");
+
+  const { collection, pipeline } = await context.queries.vendors(context, {
+    shopIds,
+    tagIds
+  });
+
+  console.log("vendors query", query);
+
+  return getPaginatedResponseFromAggregate(collection, pipeline, connectionArgs, {
+    includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),
+    includeHasPreviousPage: wasFieldRequested("pageInfo.hasPreviousPage", info),
+    includeTotalCount: wasFieldRequested("totalCount", info)
+  });
+}

--- a/src/resolvers/Query/vendors.js
+++ b/src/resolvers/Query/vendors.js
@@ -21,14 +21,10 @@ export default async function vendors(_, args, context, info) {
   const shopIds = opaqueShopIds && opaqueShopIds.map(decodeShopOpaqueId);
   const tagIds = opaqueTagIds && opaqueTagIds.map(decodeTagOpaqueId);
 
-  console.log("vendors resolver");
-
   const { collection, pipeline } = await context.queries.vendors(context, {
     shopIds,
     tagIds
   });
-
-  console.log("vendors query", query);
 
   return getPaginatedResponseFromAggregate(collection, pipeline, connectionArgs, {
     includeHasNextPage: wasFieldRequested("pageInfo.hasNextPage", info),

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -463,7 +463,7 @@ extend type Query {
   "Gets an array of all vendors"
   vendors(
     "Optionally provide a list of shop IDs from which you want to get the vendors"
-    shopIds: [ID]!
+    shopIds: [ID],
 
     "Optionally provide a list of tag IDs to further filter the vendors"
     tagIds: [ID],

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -369,6 +369,40 @@ enum CatalogItemSortByField {
   updatedAt
 }
 
+"A connection edge in which each node is a String representing a vendor"
+type VendorEdge {
+  "The cursor that represents this node in the paginated results"
+  cursor: ConnectionCursor!
+
+  "The vendor"
+  node: String
+}
+
+"""
+Wraps an array of vendors, providing pagination cursors and information.
+
+For information about what Relay-compatible connections are and how to use them, see the following articles:
+- [Relay Connection Documentation](https://facebook.github.io/relay/docs/en/graphql-server-specification.html#connections)
+- [Relay Connection Specification](https://facebook.github.io/relay/graphql/connections.htm)
+- [Using Relay-style Connections With Apollo Client](https://www.apollographql.com/docs/react/recipes/pagination.html)
+"""
+type VendorConnection {
+  "The list of nodes that match the query, wrapped in an edge to provide a cursor string for each"
+  edges: [VendorEdge]
+
+  """
+  You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
+  if you know you will not need to paginate the results.
+  """
+  nodes: [String]
+
+  "Information to help a client request the next or previous page"
+  pageInfo: PageInfo!
+
+  "The total number of nodes that match your query"
+  totalCount: Int!
+}
+
 extend type Query {
   "Gets items from a shop catalog"
   catalogItems(
@@ -417,6 +451,36 @@ extend type Query {
     "Provide either a product ID or slug"
     slugOrId: String
   ): CatalogItemProduct
+
+  "Gets an array of all vendors"
+  vendors(
+    "Optionally provide a list of shop IDs from which you want to get the vendors"
+    shopIds: [ID]!
+
+    "Optionally provide a list of tag IDs to further filter the vendors"
+    tagIds: [ID],
+
+    "Return only results that come after this cursor. Use this with `first` to specify the number of results to return."
+    after: ConnectionCursor,
+
+    "Return only results that come before this cursor. Use this with `last` to specify the number of results to return."
+    before: ConnectionCursor,
+
+    "Return at most this many results. This parameter may be used with either `after` or `offset` parameters."
+    first: ConnectionLimitInt,
+
+    "Return at most this many results. This parameter may be used with the `before` parameter."
+    last: ConnectionLimitInt,
+
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
+    "Return results sorted in this order"
+    sortOrder: SortOrder = desc,
+
+    "By default, vendors are sorted by when they were last updated, most recently updated first. Set this to sort by one of the other allowed fields"
+    sortBy: CatalogItemSortByField = updatedAt
+  ): VendorConnection
 }
 
 extend type Mutation {

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -481,10 +481,7 @@ extend type Query {
     offset: Int,
 
     "Return results sorted in this order"
-    sortOrder: SortOrder = desc,
-
-    "By default, vendors are sorted by when they were last updated, most recently updated first. Set this to sort by one of the other allowed fields"
-    sortBy: CatalogItemSortByField = updatedAt
+    sortOrder: SortOrder = asc
   ): VendorConnection
 }
 

--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -369,13 +369,18 @@ enum CatalogItemSortByField {
   updatedAt
 }
 
+type Vendor {
+  "The name of the vendor"
+  name: String
+}
+
 "A connection edge in which each node is a String representing a vendor"
 type VendorEdge {
   "The cursor that represents this node in the paginated results"
   cursor: ConnectionCursor!
 
   "The vendor"
-  node: String
+  node: Vendor
 }
 
 """
@@ -394,7 +399,7 @@ type VendorConnection {
   You can request the `nodes` directly to avoid the extra wrapping that `NodeEdge` has,
   if you know you will not need to paginate the results.
   """
-  nodes: [String]
+  nodes: [Vendor]
 
   "Information to help a client request the next or previous page"
   pageInfo: PageInfo!


### PR DESCRIPTION
Impact: **minor**
Type: **feature**

## Issue
Open Commerce currently doesn't offer a way to retrieve a list of all the vendors from the catalog items. Some storefronts, including Next Commerce, display a list of brands somewhere in the UI. There needs to be a GraphQL query to get a list of all the vendor values in the catalog.

## Solution
Implement a `vendors` query, which returns all the `product.vendor` values present in the catalog.

## Breaking changes
None.

## Testing
1. Create a few products with different values for the `vendor` field.
2. Query `vendors`.
3. Get a list of all the values for this `vendor` field.