### PR TITLE
Added name field to product search indexes for the last entry.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import {
   ImageInfo,
   ImageSizes,
   ShippingParcel,
-  SocialMetadata
+  SocialMetadata,
 } from "./simpleSchemas.js";
 
 /**
@@ -41,28 +41,34 @@ export default async function register(app) {
           [{ "product.productId": 1 }, { unique: true }],
           [{ "product.slug": 1 }],
           [{ "product.tagIds": 1 }],
-          [{
-            "product.barcode": "text",
-            "product.description": "text",
-            "product.metafields.key": "text",
-            "product.metafields.value": "text",
-            "product.metaDescription": "text",
-            "product.pageTitle": "text",
-            "product.sku": "text",
-            "product.slug": "text",
-            "product.title": "text",
-            "product.vendor": "text"
-          }]
-        ]
-      }
+          // Name field is needed due to MongoDB max index name size of 127 chars
+          [
+            {
+              "product.barcode": "text",
+              "product.description": "text",
+              "product.metafields.key": "text",
+              "product.metafields.value": "text",
+              "product.metaDescription": "text",
+              "product.pageTitle": "text",
+              "product.sku": "text",
+              "product.slug": "text",
+              "product.title": "text",
+              "product.vendor": "text",
+            },
+            {
+              name: "product_search_index",
+            },
+          ],
+        ],
+      },
     },
     functionsByType: {
       registerPluginHandler: [registerPluginHandlerForCatalog],
-      startup: [startup]
+      startup: [startup],
     },
     graphQL: {
       resolvers,
-      schemas
+      schemas,
     },
     mutations,
     queries,
@@ -74,7 +80,7 @@ export default async function register(app) {
       CatalogProductOption,
       CatalogProductVariant,
       CatalogProduct,
-      Catalog
-    }
+      Catalog,
+    },
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import {
   ImageInfo,
   ImageSizes,
   ShippingParcel,
-  SocialMetadata,
+  SocialMetadata
 } from "./simpleSchemas.js";
 
 /**
@@ -53,22 +53,22 @@ export default async function register(app) {
               "product.sku": "text",
               "product.slug": "text",
               "product.title": "text",
-              "product.vendor": "text",
+              "product.vendor": "text"
             },
             {
-              name: "product_search_index",
-            },
-          ],
-        ],
-      },
+              name: "product_search_index"
+            }
+          ]
+        ]
+      }
     },
     functionsByType: {
       registerPluginHandler: [registerPluginHandlerForCatalog],
-      startup: [startup],
+      startup: [startup]
     },
     graphQL: {
       resolvers,
-      schemas,
+      schemas
     },
     mutations,
     queries,
@@ -80,7 +80,7 @@ export default async function register(app) {
       CatalogProductOption,
       CatalogProductVariant,
       CatalogProduct,
-      Catalog,
-    },
+      Catalog
+    }
   });
 }


### PR DESCRIPTION
The auto-generated name was exceeding MongoDB max index name size of 127.

Signed-off-by: Ron W. van Etten <rondlite@gmail.com>


Impact: **minor**
Type: **bugfix**

## Issue
The auto-generated index name from:
```
    {
              "product.barcode": "text",
              "product.description": "text",
              "product.metafields.key": "text",
              "product.metafields.value": "text",
              "product.metaDescription": "text",
              "product.pageTitle": "text",
              "product.sku": "text",
              "product.slug": "text",
              "product.title": "text",
              "product.vendor": "text",
            }
```
  Is larger than the MongoDB allowed max of 127, resulting in a __namespace name generated from index name is too long__ error from MongoDB.

## Solution

Added name field `product_search_index` to the conflicting index.

## Breaking changes
none

## Testing
At startup of reaction the error _namespace name generated from index name is too long_, should no longer be present